### PR TITLE
Major Updates to Users

### DIFF
--- a/configs/releng/airootfs/customize_airootfs.sh
+++ b/configs/releng/airootfs/customize_airootfs.sh
@@ -8,7 +8,13 @@ locale-gen
 ln -sf /usr/share/zoneinfo/UTC /etc/localtime
 
 cp -aT /etc/skel/ /root/
-chmod 700 /root
+#chmod 700 /root
+
+usermod -s /usr/bin/bash root
+
+useradd -m -p "" -g users -G "adm,audio,floppy,log,network,rfkill,scanner,storage,optical,power,wheel" -s /bin/bash liveuser
+
+chown -R liveuser:users /home/liveuser
 
 mv /configs/fenrir-settings.conf /etc/fenrirscreenreader/settings/settings.conf
 rm -r /configs

--- a/configs/releng/airootfs/etc/skel/.bashrc
+++ b/configs/releng/airootfs/etc/skel/.bashrc
@@ -1,0 +1,9 @@
+#
+# ~/.bashrc
+#
+
+# If not running interactively, don't do anything
+[[ $- != *i* ]] && return
+
+alias ls='ls --color=auto'
+PS1='[\u@\h \W]\$ '

--- a/configs/releng/airootfs/etc/sudoers.d/g_wheel
+++ b/configs/releng/airootfs/etc/sudoers.d/g_wheel
@@ -1,0 +1,1 @@
+%wheel ALL=(ALL)NOPASSWD:ALL

--- a/configs/releng/airootfs/etc/systemd/system/getty@tty1.service.d/autologin.conf
+++ b/configs/releng/airootfs/etc/systemd/system/getty@tty1.service.d/autologin.conf
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=-/sbin/agetty --autologin root --noclear %I 38400 linux
+ExecStart=-/sbin/agetty --autologin liveuser --noclear %I 38400 linux

--- a/configs/releng/efiboot/loader/entries/archiso-x86_64-cd.conf
+++ b/configs/releng/efiboot/loader/entries/archiso-x86_64-cd.conf
@@ -1,4 +1,4 @@
-title   Arch Linux archiso x86_64 UEFI CD
+title   Blind Arch Linux archiso x86_64 UEFI CD
 linux   /EFI/archiso/vmlinuz.efi
 initrd  /EFI/archiso/intel_ucode.img
 initrd  /EFI/archiso/amd_ucode.img

--- a/configs/releng/efiboot/loader/entries/archiso-x86_64-usb.conf
+++ b/configs/releng/efiboot/loader/entries/archiso-x86_64-usb.conf
@@ -1,4 +1,4 @@
-title   Arch Linux archiso x86_64 UEFI USB
+title   Blind Arch Linux archiso x86_64 UEFI USB
 linux   /%INSTALL_DIR%/boot/x86_64/vmlinuz
 initrd  /%INSTALL_DIR%/boot/intel_ucode.img
 initrd  /%INSTALL_DIR%/boot/amd_ucode.img

--- a/configs/releng/packages.x86_64
+++ b/configs/releng/packages.x86_64
@@ -14,6 +14,11 @@ i3-gaps
 zsh
 zsh-completions
 termite
+compton
+networkmanager
+network-manager-applet
+xdg-user-dirs
+bash-completion
 
 # screen magnifier kmag and deps
 kmag

--- a/configs/releng/packages.x86_64
+++ b/configs/releng/packages.x86_64
@@ -15,6 +15,14 @@ zsh
 zsh-completions
 termite
 
+# screen magnifier kmag and deps
+kmag
+hicolor-icon-theme
+kio
+libqaccessibilityclient
+extra-cmake-modules
+kdoctools
+
 
 # basic packages needed to run
 alsa-utils


### PR DESCRIPTION
This adds a liveuser account and overwrites root while also giving all permissions to the liveuser.
This allows us to run i3 and kmag for those with visual impairments.

Still need to get i3 config to load properly, it is in skel and is loading, however font is bad and there are some oddities with how it is building windows also it is not generating the bar.

For now, a low vision user can at least launch i3 and get kmag to launch so they can see a magnified version of the console with black text on white background.  

Things to do:

- add larger default font (may need to install one)
- fix bar
- get i3 to load with normal default config
- make a contrast flipper
- get fenrir to launch within i3 